### PR TITLE
Add `Notion-Version` header to requests

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,18 +1,18 @@
 example_id                                           | status | run_time        |
 ---------------------------------------------------- | ------ | --------------- |
-./spec/notion/api/endpoints/blocks_spec.rb[1:1:1]    | passed | 0.01164 seconds |
-./spec/notion/api/endpoints/blocks_spec.rb[1:1:2]    | passed | 0.01245 seconds |
-./spec/notion/api/endpoints/blocks_spec.rb[1:1:3]    | passed | 0.00697 seconds |
-./spec/notion/api/endpoints/databases_spec.rb[1:1:1] | passed | 0.00697 seconds |
-./spec/notion/api/endpoints/databases_spec.rb[1:1:2] | passed | 0.00682 seconds |
-./spec/notion/api/endpoints/databases_spec.rb[1:1:3] | passed | 0.00741 seconds |
-./spec/notion/api/endpoints/databases_spec.rb[1:1:4] | passed | 0.00701 seconds |
-./spec/notion/api/endpoints/databases_spec.rb[1:1:5] | passed | 0.00795 seconds |
-./spec/notion/api/endpoints/pages_spec.rb[1:1:1]     | passed | 0.00713 seconds |
-./spec/notion/api/endpoints/pages_spec.rb[1:1:2]     | passed | 0.00774 seconds |
-./spec/notion/api/endpoints/pages_spec.rb[1:1:3]     | passed | 0.00818 seconds |
-./spec/notion/api/endpoints/users_spec.rb[1:1:1]     | passed | 0.00703 seconds |
-./spec/notion/api/endpoints/users_spec.rb[1:1:2]     | passed | 0.00683 seconds |
-./spec/notion/api/endpoints/users_spec.rb[1:1:3]     | passed | 0.00647 seconds |
-./spec/notion/config_spec.rb[1:1:1]                  | passed | 0.00006 seconds |
+./spec/notion/api/endpoints/blocks_spec.rb[1:1:1]    | passed | 0.01423 seconds |
+./spec/notion/api/endpoints/blocks_spec.rb[1:1:2]    | passed | 0.02323 seconds |
+./spec/notion/api/endpoints/blocks_spec.rb[1:1:3]    | passed | 0.00704 seconds |
+./spec/notion/api/endpoints/databases_spec.rb[1:1:1] | passed | 0.00598 seconds |
+./spec/notion/api/endpoints/databases_spec.rb[1:1:2] | passed | 0.00628 seconds |
+./spec/notion/api/endpoints/databases_spec.rb[1:1:3] | passed | 0.00548 seconds |
+./spec/notion/api/endpoints/databases_spec.rb[1:1:4] | passed | 0.00596 seconds |
+./spec/notion/api/endpoints/databases_spec.rb[1:1:5] | passed | 0.00606 seconds |
+./spec/notion/api/endpoints/pages_spec.rb[1:1:1]     | passed | 0.00581 seconds |
+./spec/notion/api/endpoints/pages_spec.rb[1:1:2]     | passed | 0.00598 seconds |
+./spec/notion/api/endpoints/pages_spec.rb[1:1:3]     | passed | 0.00717 seconds |
+./spec/notion/api/endpoints/users_spec.rb[1:1:1]     | passed | 0.00637 seconds |
+./spec/notion/api/endpoints/users_spec.rb[1:1:2]     | passed | 0.00671 seconds |
+./spec/notion/api/endpoints/users_spec.rb[1:1:3]     | passed | 0.00567 seconds |
+./spec/notion/config_spec.rb[1:1:1]                  | passed | 0.00005 seconds |
 ./spec/notion/version_spec.rb[1:1]                   | passed | 0.00005 seconds |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.0.6 (2021-06-09)
+
+- Added `Notion-Version` required header to all requests
+
 ### 0.0.5 (2020-04-25)
 
 - Added support for Blocks endpoints

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion-ruby-client (0.0.5)
+    notion-ruby-client (0.0.6)
       faraday (>= 1.0)
       faraday_middleware
       hashie
@@ -15,12 +15,16 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
@@ -31,7 +35,7 @@ GEM
     jaro_winkler (1.5.4)
     multipart-post (2.1.1)
     parallel (1.20.1)
-    parser (3.0.1.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     public_suffix (4.0.6)
     rainbow (3.0.0)
@@ -67,7 +71,7 @@ GEM
     timecop (0.9.4)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
-    webmock (3.12.2)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -88,4 +92,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.5
+   2.2.16

--- a/lib/notion/faraday/request.rb
+++ b/lib/notion/faraday/request.rb
@@ -27,6 +27,7 @@ module Notion
       def request(method, path, options)
         response = connection.send(method) do |request|
           request.headers['Authorization'] = "Bearer #{token}"
+          request.headers['Notion-Version'] = Notion::NOTION_REQUEST_VERSION
           case method
           when :get, :delete
             request.url(path, options)

--- a/lib/notion/version.rb
+++ b/lib/notion/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 module Notion
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
+  NOTION_REQUEST_VERSION = '2021-05-11'
 end


### PR DESCRIPTION
Notion now [requires a custom header](https://developers.notion.com/changelog/unversioned-requests-no-longer-accepted) added to all requests to the API. This PR adds the header to all requests from the client.