### PR TITLE
Fix query validation error in GET /page/:id endpoint

### DIFF
--- a/lib/notion/api/endpoints/pages.rb
+++ b/lib/notion/api/endpoints/pages.rb
@@ -16,7 +16,7 @@ module Notion
         #   retrieve a page that has not been archived. Defaults to false.
         def page(options = {})
           throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
-          get("pages/#{options[:id]}?archived=#{options[:archived]}")
+          get("pages/#{options[:id]}")
         end
 
         #

--- a/spec/fixtures/notion/page.yml
+++ b/spec/fixtures/notion/page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.notion.com/v1/pages/723578f1-6e51-450c-8ee1-09158c19fd4c?archived=
+    uri: https://api.notion.com/v1/pages/723578f1-6e51-450c-8ee1-09158c19fd4c
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Fixes #2 
This PR fix GET /page/:id endpoint by removing query paramater 'archived'.
Tested and it's locally working for me, but it would be great if you could test it in your notion as well.