### PR TITLE
Add Ruby 3.0 and 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle exec rake
+      - run: bundle exec rake spec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,17 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.5
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run RuboCop
+      run: bundle exec rake rubocop


### PR DESCRIPTION
This adds Ruby 3.0 and Ruby 3.1 to the CI matrix.

To get everything green I split out the linting into a separate GitHub Action.  The specified version of Rubocop is not compatible with Ruby 3.1.

Everything runs green on my fork.