### PR TITLE
Add comments endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Ruby client for the Notion API.
     - [Delete a block](#delete-a-block)
     - [Retrieve block children](#retrieve-block-children)
     - [Append block children](#append-block-children)
-  - [Comments](#users)
+  - [Comments](#comments)
     - [Retrieve comments](#retrieve-comments-from-a-page-or-block-by-id)
     - [Create a comment on a page](#create-a-comment-on-a-page)
     - [Create a comment on a discussion](#create-a-comment-on-a-discussion)
@@ -489,6 +489,8 @@ options = {
 }
 client.create_comment(options)
 ```
+
+See the full endpoint documention on [Notion Developers](https://developers.notion.com/reference/comment-object).
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A Ruby client for the Notion API.
     - [Delete a block](#delete-a-block)
     - [Retrieve block children](#retrieve-block-children)
     - [Append block children](#append-block-children)
+  - [Comments](#users)
+    - [Retrieve comments](#retrieve-comments-from-a-page-or-block-by-id)
+    - [Create a comment on a page](#create-a-comment-on-a-page)
+    - [Create a comment on a discussion](#create-a-comment-on-a-discussion)
   - [Users](#users)
     - [Retrieve your token's bot user](#retrieve-your-tokens-bot-user)
     - [Retrieve a user](#retrieve-a-user)
@@ -462,6 +466,29 @@ client.block_append_children(block_id: 'b55c9c91-384d-452b-81db-d1ef79372b75', c
 ```
 
 See the full endpoint documentation on [Notion Developers](https://developers.notion.com/reference/patch-block-children).
+
+### Comments
+
+#### Retrieve comments from a page or block by id
+```ruby
+client.retrieve_comments(block_id: '1a2f70ab26154dc7a838536a3f430af4')
+```
+#### Create a comment on a page
+```ruby
+options = {
+  page_id: '3e4bc91d36c74de595113b31c6fdb82c',
+  comment: 'your comment'
+}
+client.create_comment(options)
+```
+#### Create a comment on a discussion
+```ruby
+options = {
+  discussion_id: 'ea116af4839c410bb4ac242a18dc4392',
+  comment: 'test comment'
+}
+client.create_comment(options)
+```
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -476,8 +476,14 @@ client.retrieve_comments(block_id: '1a2f70ab26154dc7a838536a3f430af4')
 #### Create a comment on a page
 ```ruby
 options = {
-  page_id: '3e4bc91d36c74de595113b31c6fdb82c',
-  comment: 'your comment'
+  parent: { page_id: '3e4bc91d36c74de595113b31c6fdb82c' },
+  rich_text: [
+    {
+      text: {
+        content: 'Hello world'
+      }
+    }
+  ]
 }
 client.create_comment(options)
 ```
@@ -485,7 +491,13 @@ client.create_comment(options)
 ```ruby
 options = {
   discussion_id: 'ea116af4839c410bb4ac242a18dc4392',
-  comment: 'test comment'
+  rich_text: [
+    {
+      text: {
+        content: 'Hello world'
+      }
+    }
+  ]
 }
 client.create_comment(options)
 ```

--- a/lib/notion/api/endpoints.rb
+++ b/lib/notion/api/endpoints.rb
@@ -5,6 +5,7 @@ require_relative 'endpoints/databases'
 require_relative 'endpoints/pages'
 require_relative 'endpoints/users'
 require_relative 'endpoints/search'
+require_relative 'endpoints/comments'
 
 module Notion
   module Api
@@ -14,6 +15,7 @@ module Notion
       include Pages
       include Users
       include Search
+      include Comments
     end
   end
 end

--- a/lib/notion/api/endpoints/comments.rb
+++ b/lib/notion/api/endpoints/comments.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+module Notion
+  module Api
+    module Endpoints
+      module Comments
+        #
+        # Retrieves a list of un-resolved Comment objects from a page or block.
+        #
+        # @option options [id] :block_id
+        #   Block or page id to fetch comments for.
+        #
+        # @option options [start_cursor] :start_cursor
+        #   If supplied, this endpoint will return a page
+        #   of results starting after the cursor provided.
+        #   If not supplied, this endpoint will return the
+        #   first page of results.
+        #
+        # @option options [page_size] :page_size
+        #   The number of items from the full list desired in the response.
+        #   Maximum: 100
+        #
+        def retrieve_comments(options = {})
+          throw ArgumentError.new('Required arguments :block_id missing') if options[:block_id].nil?
+          params = "block_id=#{options[:block_id]}"
+          params += "&start_cursor=#{options[:start_cursor]}" unless options[:start_cursor].nil?
+          params += "&page_size=#{options[:page_size]}"       unless options[:page_size].nil?
+          get("comments?#{params}")
+        end
+
+        #
+        # Creates a comment in a page or existing discussion thread.
+        #   There are two locations you can add a new comment to:
+        #     - A page
+        #     - An existing discussion thread
+        #   If the intention is to add a new comment to a page, a parent object
+        #   must be provided in the body params. Alternatively, if a new comment
+        #   is being added to an existing discussion thread, the discussion_id string
+        #   must be provided in the body params. Exactly one of these parameters must be provided.
+        #
+        # @option options [id] :page_id
+        #   Page to add the comment to.
+        #
+        # @option options [Object] :comment
+        #   Properties of this page.
+        #   The schema for the page's keys and values is described by the properties of
+        #   the database this page belongs to. key string Name of a property as it
+        #   appears in Notion, or property ID. value object Object containing a value
+        #   specific to the property type, e.g. {"checkbox": true}.
+        def create_comment(options = {})
+          if options[:page_id].nil? && options[:discussion_id].nil?
+            throw ArgumentError.new('Required argument :page_id or :discussion_id')
+          end
+          post('comments', formatted_comment(options))
+        end
+
+        def formatted_comment(options)
+          comment_hash = { rich_text: [{ text: { content: options[:comment] } }] }
+          if options.key?(:discussion_id)
+            comment_hash[:discussion_id] = options[:discussion_id]
+          else
+            comment_hash[:parent] = { page_id: options[:page_id] }
+          end
+          comment_hash
+        end
+      end
+    end
+  end
+end

--- a/lib/notion/api/endpoints/comments.rb
+++ b/lib/notion/api/endpoints/comments.rb
@@ -21,10 +21,13 @@ module Notion
         #
         def retrieve_comments(options = {})
           throw ArgumentError.new('Required arguments :block_id missing') if options[:block_id].nil?
-          params = "block_id=#{options[:block_id]}"
-          params += "&start_cursor=#{options[:start_cursor]}" unless options[:start_cursor].nil?
-          params += "&page_size=#{options[:page_size]}"       unless options[:page_size].nil?
-          get("comments?#{params}")
+          if block_given?
+            Pagination::Cursor.new(self, :retrieve_comments, options).each do |page|
+              yield page
+            end
+          else
+            get('comments', options)
+          end
         end
 
         #
@@ -37,30 +40,20 @@ module Notion
         #   is being added to an existing discussion thread, the discussion_id string
         #   must be provided in the body params. Exactly one of these parameters must be provided.
         #
-        # @option options [id] :page_id
-        #   Page to add the comment to.
+        # @option options [Object] :parent
+        #   A page parent. Either this or a discussion_id is required (not both).
         #
-        # @option options [Object] :comment
-        #   Properties of this page.
-        #   The schema for the page's keys and values is described by the properties of
-        #   the database this page belongs to. key string Name of a property as it
-        #   appears in Notion, or property ID. value object Object containing a value
-        #   specific to the property type, e.g. {"checkbox": true}.
+        # @option options [UUID] :discussion_id
+        #   A UUID identifier for a discussion thread. Either this or a parent object is required (not both).
+        #
+        # @option options [Object] :rich_text
+        #   A rich text object.
         def create_comment(options = {})
-          if options[:page_id].nil? && options[:discussion_id].nil?
-            throw ArgumentError.new('Required argument :page_id or :discussion_id')
+          if options.dig(:parent, :page_id).nil? && options[:discussion_id].nil?
+            throw ArgumentError.new('Required argument :page_id or :discussion_id missing')
           end
-          post('comments', formatted_comment(options))
-        end
-
-        def formatted_comment(options)
-          comment_hash = { rich_text: [{ text: { content: options[:comment] } }] }
-          if options.key?(:discussion_id)
-            comment_hash[:discussion_id] = options[:discussion_id]
-          else
-            comment_hash[:parent] = { page_id: options[:page_id] }
-          end
-          comment_hash
+          throw ArgumentError.new('Required argument :rich_text missing') if options[:rich_text].nil?
+          post('comments', options)
         end
       end
     end

--- a/spec/fixtures/notion/create_discussion_comment.yml
+++ b/spec/fixtures/notion/create_discussion_comment.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/comments
+    body:
+      encoding: UTF-8
+      string: '{"rich_text":[{"text":{"content":"test comment"}}],"discussion_id":"ea116af4839c410bb4ac242a18dc4392"}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Notion Ruby Client/1.0.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Notion-Version:
+      - '2022-02-22'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 02 Sep 2022 16:29:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - notion_browser_id=060fba74-6b6c-4d17-bd99-ac0aaa23aefd; Domain=www.notion.so;
+        Path=/; Expires=Sat, 02 Sep 2023 16:29:26 GMT; Secure
+      - notion_check_cookie_consent=false; Domain=www.notion.so; Path=/; Expires=Sat,
+        03 Sep 2022 16:29:26 GMT; Secure
+      Content-Security-Policy:
+      - "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://gist.github.com https://apis.google.com
+        https://www.google.com https://www.gstatic.com https://cdn.amplitude.com https://api.amplitude.com
+        https://hkfxbbdzib.notion.so https://widget.intercom.io https://js.intercomcdn.com
+        https://static.zdassets.com https://api.smooch.io\t https://logs-01.loggly.com
+        https://http-inputs-notion.splunkcloud.com https://cdn.segment.com https://analytics.pgncs.notion.so
+        https://o324374.ingest.sentry.io https://checkout.stripe.com https://js.stripe.com
+        https://embed.typeform.com https://admin.typeform.com https://public.profitwell.com
+        js.sentry-cdn.com https://js.chilipiper.com https://platform.twitter.com https://cdn.syndication.twimg.com
+        https://accounts.google.com www.googletagmanager.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com;connect-src 'self'
+        https://msgstore.www.notion.so wss://msgstore.www.notion.so ws://localhost:*
+        ws://127.0.0.1:* https://notion-emojis.s3-us-west-2.amazonaws.com https://s3-us-west-2.amazonaws.com
+        https://s3.us-west-2.amazonaws.com https://notion-production-snapshots-2.s3.us-west-2.amazonaws.com
+        https://cdn.amplitude.com https://api.amplitude.com https://hkfxbbdzib.notion.so
+        https://www.notion.so https://api.embed.ly https://js.intercomcdn.com https://api-iam.intercom.io
+        https://uploads.intercomcdn.com wss://nexus-websocket-a.intercom.io https://ekr.zdassets.com
+        https://ekr.zendesk.com\t https://makenotion.zendesk.com\t https://api.smooch.io\t
+        wss://api.smooch.io\t https://logs-01.loggly.com https://http-inputs-notion.splunkcloud.com
+        https://cdn.segment.com https://api.segment.io https://analytics.pgncs.notion.so
+        https://api.pgncs.notion.so https://o324374.ingest.sentry.io https://checkout.stripe.com
+        https://js.stripe.com https://cdn.contentful.com https://preview.contentful.com
+        https://images.ctfassets.net https://www2.profitwell.com https://tracking.chilipiper.com
+        https://api.chilipiper.com https://api.unsplash.com https://boards-api.greenhouse.io
+        https://accounts.google.com https://oauth2.googleapis.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://region1.google-analytics.com https://region1.analytics.google.com
+        https://www.google-analytics.com https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com https://api.statuspage.io
+        https://pgncd.notion.so https://api.statsig.com https://statsigapi.net https://exp.notion.so
+        https://file.notion.so;font-src 'self' data: https://cdnjs.cloudflare.com
+        https://js.intercomcdn.com;img-src 'self' data: blob: https: https://platform.twitter.com
+        https://syndication.twitter.com https://pbs.twimg.com https://ton.twimg.com
+        https://region1.google-analytics.com https://region1.analytics.google.com;style-src
+        'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://github.githubassets.com
+        https://js.chilipiper.com https://platform.twitter.com https://ton.twimg.com
+        https://accounts.google.com;frame-src https: http: https://accounts.google.com;media-src
+        https: http: https://file.notion.so"
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=5184000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Xss-Protection:
+      - '0'
+      Etag:
+      - W/"250-4FWWLrU/GwY9p/XT7GcTdthccMw"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 74479fdd5a4e2940-ORD
+    body:
+      encoding: UTF-8
+      string: '{"object":"comment","id":"9e908609-bfcd-42d2-8f54-61c39d82351d","parent":{"type":"block_id","block_id":"1a2f70ab-2615-4dc7-a838-536a3f430af4"},"discussion_id":"ea116af4-839c-410b-b4ac-242a18dc4392","created_time":"2022-09-02T16:29:00.000Z","last_edited_time":"2022-09-02T16:29:00.000Z","created_by":{"object":"user","id":"3eb712e5-c1d7-43f2-ae18-c4d36f846aa1"},"rich_text":[{"type":"text","text":{"content":"test
+        comment","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"test
+        comment","href":null}]}'
+  recorded_at: Fri, 02 Sep 2022 16:29:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/notion/create_page_comment.yml
+++ b/spec/fixtures/notion/create_page_comment.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/comments
+    body:
+      encoding: UTF-8
+      string: '{"rich_text":[{"text":{"content":"test comment"}}],"parent":{"page_id":"3e4bc91d36c74de595113b31c6fdb82c"}}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Notion Ruby Client/1.0.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Notion-Version:
+      - '2022-02-22'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 02 Sep 2022 16:26:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - notion_browser_id=fd495a20-5f77-4a87-a210-adb2144bd55b; Domain=www.notion.so;
+        Path=/; Expires=Sat, 02 Sep 2023 16:26:31 GMT; Secure
+      - notion_check_cookie_consent=false; Domain=www.notion.so; Path=/; Expires=Sat,
+        03 Sep 2022 16:26:31 GMT; Secure
+      Content-Security-Policy:
+      - "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://gist.github.com https://apis.google.com
+        https://www.google.com https://www.gstatic.com https://cdn.amplitude.com https://api.amplitude.com
+        https://hkfxbbdzib.notion.so https://widget.intercom.io https://js.intercomcdn.com
+        https://static.zdassets.com https://api.smooch.io\t https://logs-01.loggly.com
+        https://http-inputs-notion.splunkcloud.com https://cdn.segment.com https://analytics.pgncs.notion.so
+        https://o324374.ingest.sentry.io https://checkout.stripe.com https://js.stripe.com
+        https://embed.typeform.com https://admin.typeform.com https://public.profitwell.com
+        js.sentry-cdn.com https://js.chilipiper.com https://platform.twitter.com https://cdn.syndication.twimg.com
+        https://accounts.google.com www.googletagmanager.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com;connect-src 'self'
+        https://msgstore.www.notion.so wss://msgstore.www.notion.so ws://localhost:*
+        ws://127.0.0.1:* https://notion-emojis.s3-us-west-2.amazonaws.com https://s3-us-west-2.amazonaws.com
+        https://s3.us-west-2.amazonaws.com https://notion-production-snapshots-2.s3.us-west-2.amazonaws.com
+        https://cdn.amplitude.com https://api.amplitude.com https://hkfxbbdzib.notion.so
+        https://www.notion.so https://api.embed.ly https://js.intercomcdn.com https://api-iam.intercom.io
+        https://uploads.intercomcdn.com wss://nexus-websocket-a.intercom.io https://ekr.zdassets.com
+        https://ekr.zendesk.com\t https://makenotion.zendesk.com\t https://api.smooch.io\t
+        wss://api.smooch.io\t https://logs-01.loggly.com https://http-inputs-notion.splunkcloud.com
+        https://cdn.segment.com https://api.segment.io https://analytics.pgncs.notion.so
+        https://api.pgncs.notion.so https://o324374.ingest.sentry.io https://checkout.stripe.com
+        https://js.stripe.com https://cdn.contentful.com https://preview.contentful.com
+        https://images.ctfassets.net https://www2.profitwell.com https://tracking.chilipiper.com
+        https://api.chilipiper.com https://api.unsplash.com https://boards-api.greenhouse.io
+        https://accounts.google.com https://oauth2.googleapis.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://region1.google-analytics.com https://region1.analytics.google.com
+        https://www.google-analytics.com https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com https://api.statuspage.io
+        https://pgncd.notion.so https://api.statsig.com https://statsigapi.net https://exp.notion.so
+        https://file.notion.so;font-src 'self' data: https://cdnjs.cloudflare.com
+        https://js.intercomcdn.com;img-src 'self' data: blob: https: https://platform.twitter.com
+        https://syndication.twitter.com https://pbs.twimg.com https://ton.twimg.com
+        https://region1.google-analytics.com https://region1.analytics.google.com;style-src
+        'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://github.githubassets.com
+        https://js.chilipiper.com https://platform.twitter.com https://ton.twimg.com
+        https://accounts.google.com;frame-src https: http: https://accounts.google.com;media-src
+        https: http: https://file.notion.so"
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=5184000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Xss-Protection:
+      - '0'
+      Etag:
+      - W/"24e-lwOvl3pLRgq3uaVwDU7YNYGeauA"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 74479b9bdc202d94-ORD
+    body:
+      encoding: UTF-8
+      string: '{"object":"comment","id":"95ef4675-e3c0-428c-b937-ac8d6805ac04","parent":{"type":"page_id","page_id":"3e4bc91d-36c7-4de5-9511-3b31c6fdb82c"},"discussion_id":"4cbe01af-8163-4b03-957d-cac2691b9839","created_time":"2022-09-02T16:26:00.000Z","last_edited_time":"2022-09-02T16:26:00.000Z","created_by":{"object":"user","id":"3eb712e5-c1d7-43f2-ae18-c4d36f846aa1"},"rich_text":[{"type":"text","text":{"content":"test
+        comment","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"test
+        comment","href":null}]}'
+  recorded_at: Fri, 02 Sep 2022 16:26:31 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/notion/retrieve_comments.yml
+++ b/spec/fixtures/notion/retrieve_comments.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.notion.com/v1/comments?block_id=1a2f70ab26154dc7a838536a3f430af4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Notion Ruby Client/1.0.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Notion-Version:
+      - '2022-02-22'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 02 Sep 2022 16:21:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - notion_browser_id=86d25b85-2df9-4e71-abd7-1d3e0b02bc8a; Domain=www.notion.so;
+        Path=/; Expires=Sat, 02 Sep 2023 16:21:51 GMT; Secure
+      - notion_check_cookie_consent=false; Domain=www.notion.so; Path=/; Expires=Sat,
+        03 Sep 2022 16:21:51 GMT; Secure
+      Content-Security-Policy:
+      - "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://gist.github.com https://apis.google.com
+        https://www.google.com https://www.gstatic.com https://cdn.amplitude.com https://api.amplitude.com
+        https://hkfxbbdzib.notion.so https://widget.intercom.io https://js.intercomcdn.com
+        https://static.zdassets.com https://api.smooch.io\t https://logs-01.loggly.com
+        https://http-inputs-notion.splunkcloud.com https://cdn.segment.com https://analytics.pgncs.notion.so
+        https://o324374.ingest.sentry.io https://checkout.stripe.com https://js.stripe.com
+        https://embed.typeform.com https://admin.typeform.com https://public.profitwell.com
+        js.sentry-cdn.com https://js.chilipiper.com https://platform.twitter.com https://cdn.syndication.twimg.com
+        https://accounts.google.com www.googletagmanager.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com;connect-src 'self'
+        https://msgstore.www.notion.so wss://msgstore.www.notion.so ws://localhost:*
+        ws://127.0.0.1:* https://notion-emojis.s3-us-west-2.amazonaws.com https://s3-us-west-2.amazonaws.com
+        https://s3.us-west-2.amazonaws.com https://notion-production-snapshots-2.s3.us-west-2.amazonaws.com
+        https://cdn.amplitude.com https://api.amplitude.com https://hkfxbbdzib.notion.so
+        https://www.notion.so https://api.embed.ly https://js.intercomcdn.com https://api-iam.intercom.io
+        https://uploads.intercomcdn.com wss://nexus-websocket-a.intercom.io https://ekr.zdassets.com
+        https://ekr.zendesk.com\t https://makenotion.zendesk.com\t https://api.smooch.io\t
+        wss://api.smooch.io\t https://logs-01.loggly.com https://http-inputs-notion.splunkcloud.com
+        https://cdn.segment.com https://api.segment.io https://analytics.pgncs.notion.so
+        https://api.pgncs.notion.so https://o324374.ingest.sentry.io https://checkout.stripe.com
+        https://js.stripe.com https://cdn.contentful.com https://preview.contentful.com
+        https://images.ctfassets.net https://www2.profitwell.com https://tracking.chilipiper.com
+        https://api.chilipiper.com https://api.unsplash.com https://boards-api.greenhouse.io
+        https://accounts.google.com https://oauth2.googleapis.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://region1.google-analytics.com https://region1.analytics.google.com
+        https://www.google-analytics.com https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com https://api.statuspage.io
+        https://pgncd.notion.so https://api.statsig.com https://statsigapi.net https://exp.notion.so
+        https://file.notion.so;font-src 'self' data: https://cdnjs.cloudflare.com
+        https://js.intercomcdn.com;img-src 'self' data: blob: https: https://platform.twitter.com
+        https://syndication.twitter.com https://pbs.twimg.com https://ton.twimg.com
+        https://region1.google-analytics.com https://region1.analytics.google.com;style-src
+        'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://github.githubassets.com
+        https://js.chilipiper.com https://platform.twitter.com https://ton.twimg.com
+        https://accounts.google.com;frame-src https: http: https://accounts.google.com;media-src
+        https: http: https://file.notion.so"
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=5184000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Xss-Protection:
+      - '0'
+      Etag:
+      - W/"2a4-a2pWQq0rrllNzewHfiDfmBJ/vB8"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 744794c32dac2c80-ORD
+    body:
+      encoding: UTF-8
+      string: '{"object":"list","results":[{"object":"comment","id":"8539f829-54f8-4389-a4a3-a6bc3d40636a","parent":{"type":"block_id","block_id":"1a2f70ab-2615-4dc7-a838-536a3f430af4"},"discussion_id":"ea116af4-839c-410b-b4ac-242a18dc4392","created_time":"2022-09-02T16:19:00.000Z","last_edited_time":"2022-09-02T16:19:00.000Z","created_by":{"object":"user","id":"240574f5-3adc-498c-a504-7733b0ea337b"},"rich_text":[{"type":"text","text":{"content":"hello!","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"hello!","href":null}]}],"next_cursor":null,"has_more":false,"type":"comment","comment":{}}'
+  recorded_at: Fri, 02 Sep 2022 16:21:51 GMT
+recorded_with: VCR 6.0.0

--- a/spec/notion/api/endpoints/comments_spec.rb
+++ b/spec/notion/api/endpoints/comments_spec.rb
@@ -6,13 +6,25 @@ RSpec.describe Notion::Api::Endpoints::Comments do
   let(:discussion_comment) do
     {
       discussion_id: 'ea116af4839c410bb4ac242a18dc4392',
-      comment: 'test comment'
+      rich_text: [
+        {
+          text: {
+            content: 'test comment'
+          }
+        }
+      ]
     }
   end
   let(:page_comment) do
     {
-      page_id: '3e4bc91d36c74de595113b31c6fdb82c',
-      comment: 'test comment'
+      parent: { page_id: '3e4bc91d36c74de595113b31c6fdb82c' },
+      rich_text: [
+        {
+          text: {
+            content: 'test comment'
+          }
+        }
+      ]
     }
   end
 

--- a/spec/notion/api/endpoints/comments_spec.rb
+++ b/spec/notion/api/endpoints/comments_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Notion::Api::Endpoints::Comments do
+  let(:client) { Notion::Client.new }
+  let(:discussion_comment) do
+    {
+      discussion_id: 'ea116af4839c410bb4ac242a18dc4392',
+      comment: 'test comment'
+    }
+  end
+  let(:page_comment) do
+    {
+      page_id: '3e4bc91d36c74de595113b31c6fdb82c',
+      comment: 'test comment'
+    }
+  end
+
+  describe '#retrieve_comments' do
+    it 'retrieves comments', vcr: { cassette_name: 'retrieve_comments' } do
+      response = client.retrieve_comments(block_id: '1a2f70ab26154dc7a838536a3f430af4')
+      expect(response.results.size).to eq 1
+    end
+  end
+
+  describe '#create_comment' do
+    it 'creates a comment on a page', vcr: { cassette_name: 'create_page_comment' } do
+      response = client.create_comment(page_comment)
+      expect(response.created_time).not_to be_empty
+    end
+
+    it 'creates a comment on a discussion', vcr: { cassette_name: 'create_discussion_comment' } do
+      response = client.create_comment(discussion_comment)
+      expect(response.created_time).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Adding the comments API to allow retrieval and creation of comments in Notion.

## 📖  Readme update
### Comments

#### Retrieve comments from a page or block by id
```ruby
client.retrieve_comments(block_id: '1a2f70ab26154dc7a838536a3f430af4')
```
#### Create a comment on a page
```ruby
options = {
  page_id: '3e4bc91d36c74de595113b31c6fdb82c',
  comment: 'your comment'
}
client.create_comment(options)
```
#### Create a comment on a discussion
```ruby
options = {
  discussion_id: 'ea116af4839c410bb4ac242a18dc4392',
  comment: 'test comment'
}
client.create_comment(options)
```

See the full endpoint documention on [Notion Developers](https://developers.notion.com/reference/comment-object).

## 🧪 Specs
```
Notion::Api::Endpoints::Comments
  #retrieve_comments
    retrieves comments
  #create_comment
    creates a comment on a page
    creates a comment on a discussion
```