### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ See the full endpoint documentation on [Notion Developers](https://developers.no
 
 Creates a new page in the specified database or as a child of an existing page.
 
-If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-value) of the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
+If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-values) of the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
 
 If the parent is a page, the only valid property is `title`.
 


### PR DESCRIPTION
I fixed the typo below.

- before: https://developers.notion.com/reference-link/page-property-value
- after: https://developers.notion.com/reference-link/page-property-values
