### PR TITLE
Update Ruby requirement to 2.6+, add 3.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.7
         bundler-cache: true # 'bundle install' and cache
     - name: Run RuboCop
       run: bundle exec rake rubocop


### PR DESCRIPTION
Faraday 2.0 does not support ruby 2.5 anymore.
In preparation for https://github.com/orbit-love/notion-ruby-client/pull/42, we’re updating the minimum Ruby version to 2.6+.