### PR TITLE
Remove dependency on `activesupport`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     notion-ruby-client (1.0.0)
-      activesupport (>= 6)
       dotenv
       faraday (>= 1.0)
       faraday-mashify (>= 0.1.1)
@@ -12,16 +11,9 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.1.5)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
@@ -37,10 +29,7 @@ GEM
     faraday-net_http (3.0.2)
     hashdiff (1.0.1)
     hashie (5.0.0)
-    i18n (1.10.0)
-      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    minitest (5.15.0)
     multipart-post (2.3.0)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -77,15 +66,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     timecop (0.9.4)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
     webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.5.4)
 
 PLATFORMS
   arm64-darwin-20

--- a/lib/notion-ruby-client.rb
+++ b/lib/notion-ruby-client.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'active_support/core_ext/hash/except'
 require 'faraday'
 require 'faraday/mashify'
 require 'faraday/multipart'

--- a/lib/notion/api/endpoints/blocks.rb
+++ b/lib/notion/api/endpoints/blocks.rb
@@ -28,8 +28,9 @@ module Notion
         #   updated. Currently only text (for supported block types)
         #   and checked (for to_do blocks) fields can be updated.
         def update_block(options = {})
-          throw ArgumentError.new('Required arguments :block_id missing') if options[:block_id].nil?
-          patch("blocks/#{options[:block_id]}", options.except(:block_id))
+          block_id = options.delete(:block_id)
+          throw ArgumentError.new('Required arguments :block_id missing') if block_id.nil?
+          patch("blocks/#{block_id}", options)
         end
 
         #
@@ -67,7 +68,8 @@ module Notion
               yield page
             end
           else
-            get("blocks/#{options[:block_id]}/children", options.except(:block_id))
+            block_id = options.delete(:block_id)
+            get("blocks/#{block_id}/children", options)
           end
         end
 
@@ -88,8 +90,9 @@ module Notion
         # @option options [[Object]] :children
         #   Children blocks to append
         def block_append_children(options = {})
-          throw ArgumentError.new('Required arguments :block_id missing') if options[:block_id].nil?
-          patch("blocks/#{options[:block_id]}/children", options.except(:block_id))
+          block_id = options.delete(:block_id)
+          throw ArgumentError.new('Required arguments :block_id missing') if block_id.nil?
+          patch("blocks/#{block_id}/children", options)
         end
       end
     end

--- a/lib/notion/api/endpoints/databases.rb
+++ b/lib/notion/api/endpoints/databases.rb
@@ -40,7 +40,8 @@ module Notion
               yield page
             end
           else
-            post("databases/#{options[:database_id]}/query", options.except(:database_id))
+            database_id = options.delete(:database_id)
+            post("databases/#{database_id}/query", options)
           end
         end
 
@@ -84,8 +85,9 @@ module Notion
         #   the name of the database property and the value is a property schema object.
         #
         def update_database(options = {})
-          throw ArgumentError.new('Required arguments :database_id missing') if options.dig(:database_id).nil?
-          patch("databases/#{options[:database_id]}", options.except(:database_id))
+          database_id = options.delete(:database_id)
+          throw ArgumentError.new('Required arguments :database_id missing') if database_id.nil?
+          patch("databases/#{database_id}", options)
         end
 
         #

--- a/lib/notion/api/endpoints/pages.rb
+++ b/lib/notion/api/endpoints/pages.rb
@@ -60,8 +60,9 @@ module Notion
         #   appears in Notion, or property ID. value object Object containing a value
         #   specific to the property type, e.g. {"checkbox": true}.
         def update_page(options = {})
-          throw ArgumentError.new('Required argument :page_id missing') if options[:page_id].nil?
-          patch("pages/#{options[:page_id]}", options.except(:page_id))
+          page_id = options.delete(:page_id)
+          throw ArgumentError.new('Required argument :page_id missing') if page_id.nil?
+          patch("pages/#{page_id}", options)
         end
 
         #

--- a/notion-ruby-client.gemspec
+++ b/notion-ruby-client.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/orbit-love/notion-ruby-client'
   s.licenses = ['MIT']
   s.summary = 'Notion API client for Ruby.'
-  s.add_dependency 'activesupport', '>= 6'
   s.add_dependency 'dotenv'
   s.add_dependency 'faraday', '>= 1.0'
   s.add_dependency 'faraday-mashify', '>= 0.1.1'


### PR DESCRIPTION
The dependency on `activesupport` was only used for the `Hash#except` method, which can currently be replaced by `Hash#delete` and will be part of the standard library in Ruby 3+.

Removing the dependency makes this library leaner, and avoids potential conflicts with versions in Rails-powered apps.