### PR TITLE
Added page_id as a legal parent when creating a page.  Updated NOTION…

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,14 @@ See the full endpoint documentation on [Notion Developers](https://developers.no
 
 Creates a new page in the specified database or as a child of an existing page.
 
-If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-values) of the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
+If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-values) of 
+the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
 
 If the parent is a page, the only valid property is `title`.
 
 The new page may include page content, described as [blocks](https://developers.notion.com/reference-link/block) in the children parameter.
+
+The following example creates a new page within the specified database:
 
 ```ruby
 properties = {
@@ -337,6 +340,55 @@ children = [
 ]
 client.create_page(
    parent: { database_id: 'e383bcee-e0d8-4564-9c63-900d307abdb0'},
+   properties: properties,
+   children: children
+)
+```
+
+This example creates a new page as a child of an existing page.  Note that as specified in the Notion API, when creating
+a page as a child of an existing page, the only valid property is ```title```:
+
+```ruby
+properties = {
+  title: [
+    {
+      "type": "text",
+      "text": {
+        "content": "My favorite food",
+        "link": null
+      }
+    }
+  ]
+}
+children = [
+  {
+    'object': 'block',
+    'type': 'heading_2',
+    'heading_2': {
+      'rich_text': [{
+        'type': 'text',
+        'text': { 'content': 'Lacinato kale' }
+      }]
+    }
+  },
+  {
+    'object': 'block',
+    'type': 'paragraph',
+    'paragraph': {
+      'rich_text': [
+        {
+          'type': 'text',
+          'text': {
+            'content': 'Lacinato kale is a variety of kale with a long tradition in Italian cuisine, especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale, kale, flat back kale, palm tree kale, or black Tuscan palm.',
+            'link': { 'url': 'https://en.wikipedia.org/wiki/Lacinato_kale' }
+          }
+        }
+      ]
+    }
+  }
+]
+client.create_page(
+   parent: { page_id: 'feb1cdfaab6a43cea4ecbc9e8de63ef7'},
    properties: properties,
    children: children
 )

--- a/README.md
+++ b/README.md
@@ -277,8 +277,7 @@ See the full endpoint documentation on [Notion Developers](https://developers.no
 
 Creates a new page in the specified database or as a child of an existing page.
 
-If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-values) of 
-the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
+If the parent is a database, the [property values](https://developers.notion.com/reference-link/page-property-values) of the new page in the properties parameter must conform to the parent [database](https://developers.notion.com/reference-link/database)'s property schema.
 
 If the parent is a page, the only valid property is `title`.
 
@@ -349,8 +348,7 @@ client.create_page(
 )
 ```
 
-This example creates a new page as a child of an existing page.  Note that as specified in the Notion API, when creating
-a page as a child of an existing page, the only valid property is ```title```:
+This example creates a new page as a child of an existing page.
 
 ```ruby
 properties = {

--- a/lib/notion/api/endpoints/pages.rb
+++ b/lib/notion/api/endpoints/pages.rb
@@ -38,7 +38,10 @@ module Notion
         # @option options [Object] :children
         #   An optional array of Block objects representing the Page’s content
         def create_page(options = {})
-          throw ArgumentError.new('Required argument :parent.database_id missing') if options.dig(:parent, :database_id).nil?
+          unless options.dig(:parent, :database_id).present? || options.dig(:parent, :page_id).present?
+            throw ArgumentError.new('Required argument :parent.database_id or :parent.page_id required')
+          end
+
           post("pages", options)
         end
 

--- a/lib/notion/api/endpoints/pages.rb
+++ b/lib/notion/api/endpoints/pages.rb
@@ -38,7 +38,7 @@ module Notion
         # @option options [Object] :children
         #   An optional array of Block objects representing the Page’s content
         def create_page(options = {})
-          unless options.dig(:parent, :database_id).present? || options.dig(:parent, :page_id).present?
+          if options.dig(:parent, :database_id).nil? && options.dig(:parent, :page_id).nil?
             throw ArgumentError.new('Required argument :parent.database_id or :parent.page_id required')
           end
 

--- a/lib/notion/version.rb
+++ b/lib/notion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Notion
-  VERSION = '1.1.1'
+  VERSION = '1.1.0'
   NOTION_REQUEST_VERSION = '2022-06-28'
 end

--- a/lib/notion/version.rb
+++ b/lib/notion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Notion
   VERSION = '1.1.0'
-  NOTION_REQUEST_VERSION = '2022-02-22'
+  NOTION_REQUEST_VERSION = '2022-06-28'
 end

--- a/lib/notion/version.rb
+++ b/lib/notion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Notion
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
   NOTION_REQUEST_VERSION = '2022-06-28'
 end

--- a/spec/fixtures/notion/create_page_with_parent_page.yml
+++ b/spec/fixtures/notion/create_page_with_parent_page.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notion.com/v1/pages
+    body:
+      encoding: UTF-8
+      string: '{"parent":{"page_id":"0593a719ff2e44aaa14a2bf169429284"},"properties":{"title":[{"text":{"content":"Another
+        Notion page"}}]},"children":[{"object":"block","type":"heading_2","heading_2":{"rich_text":[{"type":"text","text":{"content":"My
+        Heading 2"}}]}}]}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Notion Ruby Client/1.2.0
+      Authorization:
+      - Bearer <NOTION_API_TOKEN>
+      Notion-Version:
+      - '2022-02-22'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Feb 2023 17:21:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cf_bm=3uGTzmXnS9NSPlzB6MC25WX5a50pZafwabcoIG1k3mg-1677432114-0-AcTcZQhFHvWa2oYDeQ8RwgCXQcgn4zIPacEQnLYxg9MB0SGg74A/jZJePnsEBSNvZvZk9t9E1pL0T1zkr/KLHZE=;
+        path=/; expires=Sun, 26-Feb-23 17:51:54 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      - notion_browser_id=1d39e7da-f4cd-4161-ac33-b489ee848b04; Domain=www.notion.so;
+        Path=/; Expires=Mon, 26 Feb 2024 17:21:53 GMT; Secure
+      - notion_check_cookie_consent=false; Domain=www.notion.so; Path=/; Expires=Mon,
+        27 Feb 2023 17:21:53 GMT; Secure
+      Content-Security-Policy:
+      - "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://gist.github.com https://apis.google.com
+        https://www.google.com https://www.gstatic.com https://cdn.amplitude.com https://api.amplitude.com
+        http://dev-embed.notion.co http://embed.notion.co https://widget.intercom.io
+        https://js.intercomcdn.com https://static.zdassets.com https://api.smooch.io\t
+        https://logs-01.loggly.com https://http-inputs-notion.splunkcloud.com https://cdn.segment.com
+        https://analytics.pgncs.notion.so https://o324374.ingest.sentry.io https://checkout.stripe.com
+        https://js.stripe.com https://embed.typeform.com https://admin.typeform.com
+        https://public.profitwell.com https://static.profitwell.com js.sentry-cdn.com
+        https://js.chilipiper.com https://platform.twitter.com https://cdn.syndication.twimg.com
+        https://accounts.google.com https://www.googletagmanager.com https://www.googleadservices.com
+        https://googleads.g.doubleclick.net https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com https://cdn.metadata.io
+        https://platformapi.metadata.io https://d2hrivdxn8ekm8.cloudfront.net https://d1lu3pmaz2ilpx.cloudfront.net
+        https://dvqigh9b7wa32.cloudfront.net https://d330aiyvva2oww.cloudfront.net
+        https://cdn.transcend.io https://cdn01.boxcdn.net https://cdn.sprig.com assets.customer.io
+        code.gist.build;connect-src 'self' data: blob: https://msgstore.www.notion.so
+        wss://msgstore.www.notion.so ws://localhost:* ws://127.0.0.1:* https://notion-emojis.s3-us-west-2.amazonaws.com
+        https://s3-us-west-2.amazonaws.com https://s3.us-west-2.amazonaws.com https://notion-production-snapshots-2.s3.us-west-2.amazonaws.com
+        https://cdn.amplitude.com https://api.amplitude.com https://www.notion.so
+        https://api.embed.ly http://dev-embed.notion.co http://embed.notion.co https://js.intercomcdn.com
+        https://api-iam.intercom.io https://uploads.intercomcdn.com wss://nexus-websocket-a.intercom.io
+        https://ekr.zdassets.com https://ekr.zendesk.com\t https://makenotion.zendesk.com\t
+        https://api.smooch.io\t wss://api.smooch.io\t https://logs-01.loggly.com https://http-inputs-notion.splunkcloud.com
+        https://cdn.segment.com https://api.segment.io https://analytics.pgncs.notion.so
+        https://api.pgncs.notion.so https://o324374.ingest.sentry.io https://checkout.stripe.com
+        https://js.stripe.com https://cdn.contentful.com https://preview.contentful.com
+        https://images.ctfassets.net https://www2.profitwell.com https://tracking.chilipiper.com
+        https://api.chilipiper.com https://api.unsplash.com https://boards-api.greenhouse.io
+        https://accounts.google.com https://oauth2.googleapis.com https://www.googletagmanager.com
+        https://analytics.google.com https://www.googleadservices.com https://googleads.g.doubleclick.net
+        https://region1.google-analytics.com https://region1.analytics.google.com
+        https://www.google-analytics.com https://api-v2.mutinyhq.io https://client-registry.mutinycdn.com
+        https://client.mutinycdn.com https://user-data.mutinycdn.com https://cdn.metadata.io
+        https://platformapi.metadata.io https://d2hrivdxn8ekm8.cloudfront.net https://d1lu3pmaz2ilpx.cloudfront.net
+        https://dvqigh9b7wa32.cloudfront.net https://d330aiyvva2oww.cloudfront.net
+        https://cdn.transcend.io https://telemetry.transcend.io https://api.statuspage.io
+        https://pgncd.notion.so https://api.statsig.com https://statsigapi.net https://exp.notion.so
+        https://file.notion.so notion://file.notion.so https://api.box.com https://*.mux.com
+        https://api.sprig.com https://storage.googleapis.com https://cdn.sprig.com
+        https://cdn.userleap.com track.customer.io *.api.gist.build *.cloud.gist.build;font-src
+        'self' data: https://cdnjs.cloudflare.com https://js.intercomcdn.com https://cdn01.boxcdn.net;img-src
+        'self' data: blob: https: https://platform.twitter.com https://syndication.twitter.com
+        https://pbs.twimg.com https://ton.twimg.com https://region1.google-analytics.com
+        https://region1.analytics.google.com https://file.notion.so notion://file.notion.so
+        https://*.mux.com track.customer.io;style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com
+        https://github.githubassets.com https://js.chilipiper.com https://platform.twitter.com
+        https://ton.twimg.com https://accounts.google.com https://cdn.transcend.io
+        https://cdn01.boxcdn.net code.gist.build;media-src blob: https: http: https://file.notion.so
+        notion://file.notion.so https://*.mux.com;worker-src blob:;frame-src https:
+        http: https://accounts.google.com renderer.gist.build code.gist.build"
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=5184000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Xss-Protection:
+      - '0'
+      Etag:
+      - W/"31f-hsLSu/ULQ6imEDuQTPedr2r+doc"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 79fa5c17e98d82f8-IAD
+    body:
+      encoding: UTF-8
+      string: '{"object":"page","id":"c40d2199-e67f-4e07-875d-29f6259e7101","created_time":"2023-02-26T17:21:00.000Z","last_edited_time":"2023-02-26T17:21:00.000Z","created_by":{"object":"user","id":"baa602ec-7138-420d-bce4-a7c6cf125aa4"},"last_edited_by":{"object":"user","id":"baa602ec-7138-420d-bce4-a7c6cf125aa4"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"0593a719-ff2e-44aa-a14a-2bf169429284"},"archived":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Another
+        Notion page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Another
+        Notion page","href":null}]}},"url":"https://www.notion.so/Another-Notion-page-c40d2199e67f4e07875d29f6259e7101"}'
+  recorded_at: Sun, 26 Feb 2023 17:21:54 GMT
+recorded_with: VCR 6.0.0

--- a/spec/notion/api/endpoints/pages_spec.rb
+++ b/spec/notion/api/endpoints/pages_spec.rb
@@ -47,6 +47,47 @@ RSpec.describe Notion::Api::Endpoints::Pages do
       expect(response.properties.Name.title.first.plain_text).to eql 'Another Notion page'
     end
 
+    context 'when creating under parent page' do
+      let(:parent_page) { '0593a719-ff2e-44aa-a14a-2bf169429284' }
+      let(:properties) do
+        {
+          "title": [
+            {
+              "text": {
+                "content": 'Another Notion page'
+              }
+            }
+          ]
+        }
+      end
+      let(:children) do
+        [
+          {
+            "object": 'block',
+            "type": 'heading_2',
+            "heading_2": {
+              rich_text: [
+                {
+                  type: 'text',
+                  text: { content: 'My Heading 2' }
+                }
+              ]
+            }
+          }
+        ]
+      end
+
+      it 'creates', vcr: { cassette_name: 'create_page_with_parent_page' } do
+        response = client.create_page(
+          parent: { page_id: parent_page },
+          properties: properties,
+          children: children
+        )
+        expect(response.parent.page_id).to eql parent_page
+        expect(response.properties.title.title.first.plain_text).to eql 'Another Notion page'
+      end
+    end
+
     it 'updates', vcr: { cassette_name: 'update_page' } do
       properties = {
         "Name": [


### PR DESCRIPTION
Previously pages could only be created using a database id as the parent.  The Notion API also allows for a page id.  This PR adds support for the page_id as a parent page.  Additionally updated the NOTION API version supported.