### PR TITLE
Remove dotenv from runtime dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     notion-ruby-client (1.2.1)
-      dotenv
       faraday (>= 2.0)
       faraday-mashify (>= 0.1.1)
       faraday-multipart (>= 1.0.4)
@@ -79,6 +78,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dotenv
   notion-ruby-client!
   rake (~> 13)
   rspec

--- a/notion-ruby-client.gemspec
+++ b/notion-ruby-client.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/orbit-love/notion-ruby-client'
   s.licenses = ['MIT']
   s.summary = 'Notion API client for Ruby.'
-  s.add_dependency 'dotenv'
   s.add_dependency 'faraday', '>= 2.0'
   s.add_dependency 'faraday-mashify', '>= 0.1.1'
   s.add_dependency 'faraday-multipart', '>= 1.0.4'
   s.add_dependency 'hashie', '~> 5'
+  s.add_development_dependency 'dotenv'
   s.add_development_dependency 'rake', '~> 13'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '~> 0.82.0'


### PR DESCRIPTION
dotenv is used in bin/console but not in runtime.
This commit removes dotenv from runtime dependencies so that users do not have to install extra dependencies.
